### PR TITLE
Add welcome onboarding dialog

### DIFF
--- a/Blitzit_App/config.json
+++ b/Blitzit_App/config.json
@@ -1,3 +1,4 @@
 {
-    "theme": "dark"
+  "theme": "dark",
+  "show_welcome": true
 }

--- a/Blitzit_App/main.py
+++ b/Blitzit_App/main.py
@@ -16,6 +16,7 @@ from widgets.column_widget import DropColumn
 from widgets.eisenhower_widget import EisenhowerMatrix, QuadrantWidget
 from widgets.floating_widget import FloatingWidget
 from widgets.today_list_widget import TodayListWidget
+from widgets.welcome_dialog import WelcomeDialog
 
 # --- CONFIG AND STYLESHEET MANAGEMENT ---
 CONFIG_FILE = "config.json"
@@ -24,9 +25,14 @@ def load_config():
     """Loads the configuration file (e.g., for theme choice)."""
     try:
         with open(CONFIG_FILE, 'r') as f:
-            return json.load(f)
+            config = json.load(f)
+            if 'theme' not in config:
+                config['theme'] = 'dark'
+            if 'show_welcome' not in config:
+                config['show_welcome'] = True
+            return config
     except (FileNotFoundError, json.JSONDecodeError):
-        return {"theme": "dark"} # Default to dark theme
+        return {"theme": "dark", "show_welcome": True}
 
 def save_config(config):
     """Saves the configuration file."""
@@ -168,8 +174,17 @@ class BlitzitApp(QMainWindow):
         self.celebration.hide()
         self.single_task_float.hide()
         self.today_list_float.hide()
-        
+
         self.load_projects()
+        self.show_welcome_if_needed()
+
+    def show_welcome_if_needed(self):
+        config = load_config()
+        if config.get("show_welcome", True):
+            dialog = WelcomeDialog(self)
+            if dialog.exec() and dialog.do_not_show_again():
+                config["show_welcome"] = False
+                save_config(config)
 
     def change_theme(self, theme_name):
         """Loads and applies a new theme stylesheet and saves the choice."""

--- a/Blitzit_App/widgets/welcome_dialog.py
+++ b/Blitzit_App/widgets/welcome_dialog.py
@@ -1,0 +1,25 @@
+from PyQt6.QtWidgets import QDialog, QVBoxLayout, QLabel, QCheckBox, QPushButton
+
+class WelcomeDialog(QDialog):
+    """Simple onboarding dialog shown on first launch."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Welcome to Blitzit")
+        layout = QVBoxLayout(self)
+        msg = (
+            "<b>Welcome to Blitzit Productivity Hub!</b><br><br>"
+            "Use the <i>Board</i> view to organize tasks by column.\n"
+            "Switch to the <i>Matrix</i> view to prioritize them by urgency and importance.\n"
+            "Use <b>Blitz Now</b> to focus on tasks in your 'Today' list."
+        )
+        label = QLabel(msg)
+        label.setWordWrap(True)
+        layout.addWidget(label)
+        self.checkbox = QCheckBox("Don't show this again")
+        layout.addWidget(self.checkbox)
+        ok_btn = QPushButton("OK")
+        ok_btn.clicked.connect(self.accept)
+        layout.addWidget(ok_btn)
+
+    def do_not_show_again(self):
+        return self.checkbox.isChecked()


### PR DESCRIPTION
## Summary
- introduce `WelcomeDialog` onboarding window
- store `show_welcome` flag in `config.json`
- display welcome dialog on first launch

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686132829e84832792b2df364e1c7dbb