### PR TITLE
feat: Display task count in board view column headers

### DIFF
--- a/Blitzit_App/main.py
+++ b/Blitzit_App/main.py
@@ -271,6 +271,11 @@ class BlitzitApp(QMainWindow):
             task_widget = TaskWidget(task); task_widget.task_completed.connect(self.complete_task); task_widget.task_deleted.connect(self.delete_task)
             task_widget.task_edit_requested.connect(self.open_edit_task_dialog); task_widget.focus_requested.connect(self.start_focus_mode); task_widget.task_reopened.connect(self.reopen_task)
             if task["column"] in self.columns: self.columns[task["column"]].tasks_layout.addWidget(task_widget)
+
+        # Update task counts for all columns
+        for col_name in self.columns:
+            self.columns[col_name].update_task_count_display()
+
         active_tasks = [t for t in tasks_to_display if t['column'] != 'Done']
         self.matrix_view.populate_matrix(active_tasks)
 
@@ -311,6 +316,11 @@ class BlitzitApp(QMainWindow):
                 if source_container.column_name != new_column_name:
                     source_ids = [source_layout.itemAt(i).widget().task_id for i in range(source_layout.count())]
                     database.update_task_order(source_ids)
+
+                # Update task counts for affected columns
+                self.columns[new_column_name].update_task_count_display()
+                if source_container.column_name != new_column_name:
+                    self.columns[source_container.column_name].update_task_count_display()
             else:
                 # Fallback to a full refresh if something goes wrong
                 self.refresh_all_views()
@@ -383,7 +393,9 @@ class BlitzitApp(QMainWindow):
     def reopen_task(self, task_id): database.update_task_column(task_id, "Today"); self.refresh_all_views()
     
     def complete_task(self, task_id):
-        database.update_task_column(task_id, "Done"); self.celebration.show_celebration()
+        database.update_task_column(task_id, "Done")
+        self.refresh_all_views() # Refresh to update counts and UI state
+        self.celebration.show_celebration()
 
     def open_add_task_dialog(self):
         if self.current_project_id is None or self.current_project_id == -1: QMessageBox.warning(self, "Cannot Add Task", "Please select a specific project to add a new task."); return

--- a/Blitzit_App/widgets/column_widget.py
+++ b/Blitzit_App/widgets/column_widget.py
@@ -11,15 +11,32 @@ class DropColumn(QFrame):
     def __init__(self, title, parent=None):
         super().__init__(parent)
         self.column_name = title
+        self.original_title = title # Store the original title
         self.setAcceptDrops(True)
         self.setObjectName("ColumnFrame")
 
-        self.main_layout = QVBoxLayout(self); title_label = QLabel(title); title_label.setObjectName("ColumnTitle")
-        self.main_layout.addWidget(title_label)
+        self.main_layout = QVBoxLayout(self)
+        self.title_label = QLabel(title) # Store title_label as an instance attribute
+        self.title_label.setObjectName("ColumnTitle")
+        self.main_layout.addWidget(self.title_label)
+
         self.tasks_layout = QVBoxLayout(); self.tasks_layout.setSpacing(0); self.tasks_layout.setContentsMargins(0,0,0,0)
         self.tasks_layout.setAlignment(Qt.AlignmentFlag.AlignTop)
         wrapper_widget = QWidget(); wrapper_widget.setLayout(self.tasks_layout); scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True); scroll_area.setWidget(wrapper_widget); self.main_layout.addWidget(scroll_area)
+
+    def update_task_count_display(self):
+        count = self.tasks_layout.count()
+        # Special handling for "Today" column's title if it has the "Blitz Now" button
+        # The actual title label is within a QHBoxLayout which is the first item in main_layout
+        if self.original_title == "Today" and self.main_layout.itemAt(0) and isinstance(self.main_layout.itemAt(0), QHBoxLayout):
+            header_layout = self.main_layout.itemAt(0)
+            # Assuming the original title QLabel is the first widget in this header_layout
+            actual_title_label = header_layout.itemAt(0).widget()
+            if actual_title_label and isinstance(actual_title_label, QLabel):
+                actual_title_label.setText(f"{self.original_title} ({count})")
+        else:
+            self.title_label.setText(f"{self.original_title} ({count})")
 
     def dragEnterEvent(self, event):
         if event.mimeData().hasFormat("text/plain"):


### PR DESCRIPTION
Added a task count to the header of each column in the board view (e.g., "Today (3)").

Changes:
- Modified `DropColumn` in `widgets/column_widget.py`:
    - Stored the original title separately.
    - Added `update_task_count_display()` method to update the title label with the current task count from its `tasks_layout`.
    - Ensured this handles the special header layout of the "Today" column (with the "Blitz Now" button).
- Modified `BlitzitApp` in `main.py`:
    - Called `update_task_count_display()` for all columns in `refresh_all_views()` after tasks are populated.
    - Ensured dynamic updates by calling `update_task_count_display()` for affected columns in `handle_task_drop()` after a surgical UI move.
    - Added a call to `refresh_all_views()` in `complete_task()` to ensure UI consistency and count updates after a task is marked done.

This provides users with an immediate visual cue of the number of tasks in each column, enhancing the usability of the board view.