### PR TITLE
Implement Pomodoro cycles and font size setting

### DIFF
--- a/Blitzit_App/config.json
+++ b/Blitzit_App/config.json
@@ -1,4 +1,5 @@
-
-
-    "theme": "dark",
-    "show_welcome": false
+{
+  "theme": "dark",
+  "show_welcome": true,
+  "font_size": 10
+}


### PR DESCRIPTION
## Summary
- extend timer widget to support automatic Pomodoro cycles
- add config file with font size option
- allow changing font size from the main window

## Testing
- `python -m py_compile Blitzit_App/main.py Blitzit_App/widgets/timer_widget.py`

------
https://chatgpt.com/codex/tasks/task_b_68616bf772cc8327afa16d87417d3ee7